### PR TITLE
fix: Corrigir paginação após exclusão de vídeo para evitar erro de range

### DIFF
--- a/src/hooks/useVideoManager.ts
+++ b/src/hooks/useVideoManager.ts
@@ -90,6 +90,8 @@ export const useVideoManager = () => {
       });
 
       console.log('[useVideoManager] handleDeleteVideo: Sucesso na exclusão, prestes a chamar loadVideos().');
+      console.log('[useVideoManager] handleDeleteVideo: Resetando página para 1.');
+      setPage(1);
       loadVideos();
     } catch (error) {
       console.error('[useVideoManager] Erro capturado no CATCH EXTERNO de handleDeleteVideo:', error);
@@ -123,6 +125,8 @@ export const useVideoManager = () => {
 
       setSelectedVideos([]);
       console.log('[useVideoManager] handleBulkDelete: Sucesso na exclusão em massa, prestes a chamar loadVideos().');
+      console.log('[useVideoManager] handleBulkDelete: Resetando página para 1.');
+      setPage(1);
       loadVideos();
     } catch (error) {
       console.error('[useVideoManager] Erro capturado no CATCH EXTERNO de handleBulkDelete:', error);
@@ -229,6 +233,7 @@ export const useVideoManager = () => {
 
   // Aplicar filtros
   const handleFilterChange = (newFilters: VideoFilterOptions) => { // Usar VideoFilterOptions
+    console.log('[useVideoManager] handleFilterChange: Resetando página para 1 devido à mudança de filtros. Novos filtros:', newFilters);
     setFilters(newFilters);
     setPage(1);
   };


### PR DESCRIPTION
Este commit corrige um problema onde a lista de vídeos não era exibida corretamente após uma operação de exclusão. O erro ocorria porque o estado de paginação não era resetado, levando a uma tentativa de buscar uma página de dados que não existia mais (resultando em um erro HTTP 416 Range Not Satisfiable).

Alterações:
- No hook `useVideoManager.ts`:
  - Nas funções `handleDeleteVideo` e `handleBulkDelete`, a paginação agora é resetada para a primeira página (`setPage(1)`) imediatamente antes de chamar `loadVideos()` para recarregar a lista.
  - Foram adicionados logs (`console.log`) para rastrear as chamadas a `setPage(1)` nas funções de exclusão e na função `handleFilterChange`, facilitando a depuração do comportamento da paginação.

Com esta correção, após a exclusão de um ou mais vídeos, a interface do usuário buscará e exibirá a primeira página da lista de vídeos atualizada, prevenindo o erro "Range Not Satisfiable" e garantindo que a UI reflita corretamente o estado dos dados.